### PR TITLE
Banner menu links display under main nav on mobile

### DIFF
--- a/config/block.block.saplings_child_banner.yml
+++ b/config/block.block.saplings_child_banner.yml
@@ -10,10 +10,10 @@ dependencies:
     - saplings_child
 third_party_settings:
   block_class:
-    classes: 'col col-12'
+    classes: 'd-block d-lg-none'
 id: saplings_child_banner
 theme: saplings_child
-region: banner
+region: navigation_collapsible
 weight: -5
 provider: null
 plugin: 'system_menu_block:banner'

--- a/config/block.block.saplings_child_banner_2.yml
+++ b/config/block.block.saplings_child_banner_2.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.banner
+  module:
+    - system
+  theme:
+    - saplings_child
+id: saplings_child_banner_2
+theme: saplings_child
+region: banner
+weight: 0
+provider: null
+plugin: 'system_menu_block:banner'
+settings:
+  id: 'system_menu_block:banner'
+  label: Banner
+  label_display: '0'
+  provider: system
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/config/block.block.saplings_child_mainnavigation.yml
+++ b/config/block.block.saplings_child_mainnavigation.yml
@@ -10,7 +10,7 @@ dependencies:
 id: saplings_child_mainnavigation
 theme: saplings_child
 region: navigation_collapsible
-weight: 0
+weight: -6
 provider: null
 plugin: 'system_menu_block:main'
 settings:

--- a/recipe.yml
+++ b/recipe.yml
@@ -27,6 +27,8 @@ config:
     ds: "*"
     # Import blocks that Stark does not automatically create below.
     saplings_child:
+      - block.block.saplings_child_banner_2.yml
+      - block.block.saplings_child_banner.yml
       - block.block.saplings_child_breadcrumbs.yml
       - block.block.saplings_child_content.yml
       - block.block.saplings_child_footer.yml


### PR DESCRIPTION
## Description
Banner menu links display one under the other. This PR hides the banner menu on screens smaller than lg. In another pr on saplings-theme repo the config will be added to display the banner nav underneath the main menu links.

## Related Ticket
https://kanopi.teamwork.com/app/tasks/29490939

## Deploy Notes
https://github.com/kanopi/saplings-theme/pull/16
Depends on this PR to work correctly
https://github.com/kanopi/saplings_child/pull/44

