### PR TITLE
Update block.block.saplings_child_social.yml

### DIFF
--- a/config/block.block.saplings_child_social.yml
+++ b/config/block.block.saplings_child_social.yml
@@ -5,20 +5,9 @@ dependencies:
     - system.menu.social
   module:
     - system
-    - ui_styles
   theme:
     - saplings_child
-third_party_settings:
-  ui_styles:
-    block:
-      selected: {  }
-      extra: ''
-    title:
-      selected: {  }
-      extra: ''
-    content:
-      selected: {  }
-      extra: ''
+third_party_settings: {  }
 id: saplings_child_social
 theme: saplings_child
 region: footer


### PR DESCRIPTION
Got a validation error on Drupal 11.1.  This PR removes the third party settings as they are all blank anyway.


```
In RecipeConfigInstaller.php line 70:

  There were validation errors in block.block.saplings_child_social:
  - third_party_settings.ui_styles.block: 'block' is not a supported key.
  - third_party_settings.ui_styles.title: 'title' is not a supported key.
  - third_party_settings.ui_styles.content: 'content' is not a supported key.
  - third_party_settings.ui_styles: 'uuid' is a required key.
  - third_party_settings.ui_styles: 'langcode' is a required key.
  - third_party_settings.ui_styles: 'status' is a required key.
  - third_party_settings.ui_styles: 'dependencies' is a required key.
  - third_party_settings.ui_styles: 'id' is a required key.
  - third_party_settings.ui_styles: 'theme' is a required key.
  - third_party_settings.ui_styles: 'region' is a required key.
  - third_party_settings.ui_styles: 'weight' is a required key.
  - third_party_settings.ui_styles: 'provider' is a required key.
  - third_party_settings.ui_styles: 'plugin' is a required key.
  - third_party_settings.ui_styles: 'settings' is a required key.
  - third_party_settings.ui_styles: 'visibility' is a required key.
  - ```